### PR TITLE
Lecture 8 - Permissions & Location

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,4 +39,6 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.1.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:4.1.0'
     implementation 'com.squareup.picasso:picasso:2.71828'
+    implementation 'com.google.android.gms:play-services-location:17.0.0'
+
 }


### PR DESCRIPTION
## Summary
We added the ability to prompt for the Location permission to use the user's current location for the selection on the Maps screen.

We also looked at:
- Using an Intent to launch the Settings app to the Android Tweets app so that the user could manually grant the location permission (if they had denied and checked `Don't ask again`).
- Requesting constant location updates

I "reverted" both of these two changes (they are still in the slides), since they're not as practical for the Android Tweets app.

## Screenshots
<img width="350" alt="Screen Shot 2020-03-03 at 22 36 10" src="https://user-images.githubusercontent.com/5898509/75842906-b40aa080-5d9f-11ea-959b-596adfc1cde2.png">

<img width="1354" alt="Screen Shot 2020-03-03 at 22 34 21" src="https://user-images.githubusercontent.com/5898509/75842913-b8cf5480-5d9f-11ea-9e9a-950b6327a7e4.png">
