### PR TITLE
Lecture 11 - Part 2 - Screen Rotation

### DIFF
--- a/app/src/main/java/edu/gwu/androidtweets/Tweet.kt
+++ b/app/src/main/java/edu/gwu/androidtweets/Tweet.kt
@@ -1,11 +1,13 @@
 package edu.gwu.androidtweets
 
+import java.io.Serializable
+
 data class Tweet(
     val username: String,
     val handle: String,
     val content: String,
     val iconUrl: String
-) {
+) : Serializable {
     // Required by Firebase DB when using getValue on data retrieved from the DB
     constructor() : this("", "", "", "")
 }

--- a/app/src/main/java/edu/gwu/androidtweets/TweetsActivity.kt
+++ b/app/src/main/java/edu/gwu/androidtweets/TweetsActivity.kt
@@ -2,9 +2,11 @@ package edu.gwu.androidtweets
 
 import android.location.Address
 import android.os.Bundle
+import android.util.Log
 import android.widget.EditText
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.isGone
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -15,6 +17,7 @@ import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ValueEventListener
 import org.jetbrains.anko.doAsync
+import java.util.ArrayList
 
 class TweetsActivity : AppCompatActivity() {
 
@@ -27,6 +30,8 @@ class TweetsActivity : AppCompatActivity() {
     private lateinit var firebaseDatabase: FirebaseDatabase
 
     private lateinit var firebaseAnalytics: FirebaseAnalytics
+
+    private val currentTweets: MutableList<Tweet> = mutableListOf()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -47,8 +52,24 @@ class TweetsActivity : AppCompatActivity() {
         // Set the RecyclerView direction to vertical (the default)
         recyclerView.layoutManager = LinearLayoutManager(this)
 
-        // getTweetsFromTwitter(currentAddress)
-        getTweetsFromFirebase(currentAddress)
+        if (savedInstanceState != null) {
+            Log.d("TweetsActivity", "After rotation - Using saved Tweets")
+
+            val savedTweets: List<Tweet> = savedInstanceState.getSerializable("TWEETS") as List<Tweet>
+            currentTweets.addAll(savedTweets)
+
+            val adapter = TweetAdapter(currentTweets)
+            recyclerView.adapter = adapter
+        } else {
+            Log.d("TweetsActivity", "First time - getting Tweets from Twitter")
+            getTweetsFromTwitter(currentAddress)
+//        getTweetsFromFirebase(currentAddress)
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putSerializable("TWEETS", ArrayList(currentTweets))
     }
 
     /**
@@ -124,6 +145,9 @@ class TweetsActivity : AppCompatActivity() {
      * word "Android" nearby the passed [Address].
      */
     fun getTweetsFromTwitter(currentAddress: Address) {
+        addTweet.hide()
+        tweetContent.isGone = true
+
         // Networking is required to happen on a background thread, especially since server response
         // times can be long if the user has a poor internet connection.
         doAsync {
@@ -146,6 +170,9 @@ class TweetsActivity : AppCompatActivity() {
                     latitude = currentAddress.latitude,
                     longitude = currentAddress.longitude
                 )
+
+                currentTweets.clear()
+                currentTweets.addAll(tweets)
 
                 firebaseAnalytics.logEvent("tweets_retrieval_success_twitter", null)
 


### PR DESCRIPTION
## Summary
We saw some issues caused by screen rotation (or, more broadly speaking, configuration changes) -- for example, duplicate Twitter API calls or data loss on the Maps screen.

We looked into using `onSaveInstanceState` and its `Bundle` to save the state of the `TweetsActivity` so that API calls are no re-made after screen rotation.

This PR also sets our `TweetsActivity` up so that it is going to Twitter again for Tweets, rather than Firebase.